### PR TITLE
removed Urllib2 dependency as it no longer available via pip

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,5 +12,4 @@ python-socketio
 six
 Werkzeug
 eventlet
-urllib2
 requests


### PR DESCRIPTION
The same is already included in the core folder.