### PR TITLE
Remove standard library from requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,5 +12,4 @@ python-socketio
 six
 Werkzeug
 eventlet
-urllib2
 requests


### PR DESCRIPTION
`urllib2` is a part of the standard library and should not be installed using pip. Running `pip install -r requirements.txt` would result in the following error: 
```
Could not find a version that satisfies the requirement urllib2 (from -r requirements.txt (line 15)) (from versions: )
No matching distribution found for urllib2 (from -r requirements.txt (line 15))
```