### PR TITLE
Modernize Python 2 code to get ready for Python 3

### DIFF
--- a/core/db.py
+++ b/core/db.py
@@ -34,21 +34,21 @@ class Database(object):
         return True
 
     def sql_execute(self, sentence):
-    	if type(sentence) is str:
+    	if isinstance(sentence, str):
         	self.cursor.execute(sentence)
     	else:
         	self.cursor.execute(sentence[0], sentence[1])
         return self.cursor.fetchall()
 
     def sql_one_row(self, sentence, column):
-        if type(sentence) is str:
+        if isinstance(sentence, str):
         	self.cursor.execute(sentence)
     	else:
         	self.cursor.execute(sentence[0], sentence[1])	
         return self.cursor.fetchone()[column]
 
     def sql_insert(self, sentence):
-        if type(sentence) is str:
+        if isinstance(sentence, str):
         	self.cursor.execute(sentence)
     	else:
         	self.cursor.execute(sentence[0], sentence[1])

--- a/core/dependence/urllib2.py
+++ b/core/dependence/urllib2.py
@@ -458,7 +458,7 @@ def build_opener(*handlers):
     """
     import types
     def isclass(obj):
-        return isinstance(obj, (types.ClassType, type))
+        return isinstance(obj, type)
 
     opener = OpenerDirector()
     default_classes = [ProxyHandler, UnknownHandler, HTTPHandler,
@@ -1172,7 +1172,7 @@ class AbstractHTTPHandler(BaseHandler):
 
         try:
             h.request(req.get_method(), req.get_selector(), req.data, headers)
-        except socket.error, err: # XXX what error?
+        except socket.error as err: # XXX what error?
             h.close()
             raise URLError(err)
         else:
@@ -1345,7 +1345,7 @@ class FileHandler(BaseHandler):
                 else:
                     origurl = 'file://' + filename
                 return addinfourl(open(localfile, 'rb'), headers, origurl)
-        except OSError, msg:
+        except OSError as msg:
             # urllib2 users shouldn't expect OSErrors coming from urlopen()
             raise URLError(msg)
         raise URLError('file not on local host')
@@ -1375,7 +1375,7 @@ class FTPHandler(BaseHandler):
 
         try:
             host = socket.gethostbyname(host)
-        except socket.error, msg:
+        except socket.error as msg:
             raise URLError(msg)
         path, attrs = splitattr(req.get_selector())
         dirs = path.split('/')
@@ -1401,7 +1401,7 @@ class FTPHandler(BaseHandler):
             sf = StringIO(headers)
             headers = mimetools.Message(sf)
             return addinfourl(fp, headers, req.get_full_url())
-        except ftplib.all_errors, msg:
+        except ftplib.all_errors as msg:
             raise URLError, ('ftp error: %s' % msg), sys.exc_info()[2]
 
     def connect_ftp(self, user, passwd, host, port, dirs, timeout):

--- a/core/ngrok.py
+++ b/core/ngrok.py
@@ -11,6 +11,7 @@
 #
 # Copyright 2018 by Jose Pino (@jofpin) / <jofpin@gmail.com>
 #**
+from __future__ import print_function
 import sys
 import os, platform
 import subprocess
@@ -23,7 +24,7 @@ class ngrok(object):
 		if authtoken:
 			self.token = authtoken
 		else:
-			print "Can't use Ngrok without a valid token"
+			print("Can't use Ngrok without a valid token")
 		system_type = os.name
 		system_name = platform.system()
 		system_architecture = platform.architecture()[0]
@@ -79,4 +80,4 @@ def start_ngrok(port, hash, f=0):
 		if "nt" in system_type:
 			str_ngrok = './ngrok.exe'
 		result = subprocess.check_output([str_ngrok, "http", port, '-log', hash + '.nlog'])
-		print result
+		print(result)


### PR DESCRIPTION
* Old style exceptions --> new style for Python 3
    * Python 3 treats old style exceptions as syntax errors but new style exceptions work as expected in both Python 2 and Python 3.
* Use __print()__ function in both Python 2 and Python 3
    * __print()__ is a function in Python 3.