### PR TITLE
Fix configuration JSON dumping and parsing error.

### DIFF
--- a/core/trape.py
+++ b/core/trape.py
@@ -279,7 +279,7 @@ class Trape(object):
 		utils.Go("")
 		time.sleep(0.4)
 		if (c_nGrokToken != '' and c_gMapsToken != ''):
-			v = '{\n\t"ngrok_token" : "' + c_nGrokToken + '",\n\t"gmaps_api_key" : "' + c_gMapsToken + '",\n\t"gshortener_api_key" : "' + c_gOoglToken + '"\n\t"ipinfo_api_key" : "' + c_ipinfo + '",\n}'
+			v = json.dumps(dict(ngrok_token=c_nGrokToken, gmaps_api_key=c_gMapsToken, gshortener_api_key=c_gOoglToken, ipinfo_api_key=c_ipinfo), indent=2)
 			f = open ('trape.config', 'w')
 			f.write(v)
 			f.close()


### PR DESCRIPTION
I came across an error while testing. It seems parsing the `trape.config` file is failing:

![trape_error](https://user-images.githubusercontent.com/26286907/77778039-74af3700-7061-11ea-86da-ab9b6c450005.gif)

![image](https://user-images.githubusercontent.com/26286907/77777799-21d57f80-7061-11ea-9faa-9b1ffa1eab61.png)
