### PR TITLE
docs: fix simple typo, knowlege -> knowledge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ trape (stable) v2.0
 People tracker on the Internet: Learn to track the world, to avoid being traced.
 
 ---
-Trape is an **OSINT** analysis and research tool, which allows people to track and execute intelligent **social engineering** attacks in real time. It was created with the aim of teaching the world how large Internet companies could obtain **confidential information** such as the status of sessions of their websites or services and control their users through their browser, without their knowlege, but It evolves with the aim of helping **government** organizations, companies and **researchers** to track the cybercriminals.
+Trape is an **OSINT** analysis and research tool, which allows people to track and execute intelligent **social engineering** attacks in real time. It was created with the aim of teaching the world how large Internet companies could obtain **confidential information** such as the status of sessions of their websites or services and control their users through their browser, without their knowledge, but It evolves with the aim of helping **government** organizations, companies and **researchers** to track the cybercriminals.
 
 ![--trape header](https://i.imgur.com/2ycpXEj.png)
 


### PR DESCRIPTION
There is a small typo in README.md.

Should read `knowledge` rather than `knowlege`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md